### PR TITLE
Add role to create link to PMA toplevel directory for config.inc.php

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,13 @@
     insertafter="EOF"
   become: true
 
+- name: Create link to PMA toplevel directory for config.inc.php
+  file:
+    src: /etc/phpmyadmin/config.inc.php
+    dest: /usr/share/phpmyadmin/config.inc.php
+    state: link
+  become: yes
+
 - name: Restart apache
   service: name=apache2 state=restarted
   become: yes


### PR DESCRIPTION
The config files stay on /etc/phpmyadmin/ and the files exec of PMA on /usr/share/phpmyadmin/.

Therefore I have added a role which create the symlink between 
(/etc/phpmyadmin/config.inc.php) <--> (/usr/share/phpmyadmin/config.inc.php). 

And so the config files still on old path and files exec also. 